### PR TITLE
allow parameters to be specified in script path

### DIFF
--- a/Content/Scripts/scriptHandler.js
+++ b/Content/Scripts/scriptHandler.js
@@ -11,9 +11,16 @@ const startScript = (scriptName, socket, scriptPath)=>{
 	if(!scriptPath){
 		scriptPath = './';
 	}
-	let fullScriptPath = scriptPath + scriptName;
 
-	let child = childProcess.fork(scriptPath + scriptName, [], { silent: true });
+	// QUICKFIX: allow parameters to be specified in script path, separated from script path by |
+	let scriptNameAndParameters = scriptName.split('|');
+	let fullScriptPath = scriptPath + scriptNameAndParameters[0];
+	let parameters = [];
+
+	if (scriptNameAndParameters[1])
+		parameters = scriptNameAndParameters[1].match(/[^"]+|[^\s"]+/g);
+
+	let child = childProcess.fork(fullScriptPath, parameters, { silent: true });
 	ipc = new IPCEventEmitter(child);
 	let pid = child.pid;
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ In your component properties set the name of the script you wish to run e.g. ```
 
 ![set script](https://i.imgur.com/xalQplZ.png)
 
+### Command line arguments
+
+Command line arguments are supported, just add them to the script path, separated by "|".
+Arguments which contain spaces should be enclosed in double quotes. Example:
+
+`myscript.js|--parameter=value "--parameter-with-spaces=value with spaces"` 
+
 Now let's look at a basic script
 
 ### Node Scripts


### PR DESCRIPTION
Solves #15, parameters are separated from script path by "|".

Parameters with spaces should be enclosed in double quotes, example:

myscript.js|--upload "--file=C:\My Documents\myfile.txt"